### PR TITLE
Link to internal modules mentioned in README

### DIFF
--- a/lib/Template6.rakumod
+++ b/lib/Template6.rakumod
@@ -82,7 +82,7 @@ These are very simplistic at the moment, but work for basic tests.
 =item WRAPPER statement
 =item block statements
 =item given/when statements
-=item Add 'absolute' and 'relative' options to Template6::Provider::File
+=item Add 'absolute' and 'relative' options to L<Template6::Provider::File|lib/Template6/Provider/File.rakumod>
 =item Whitespace control
 =item Precompiled/cached templates
 =item Tag styles (limited to definable start_tag and end_tag)
@@ -100,7 +100,7 @@ These are very simplistic at the moment, but work for basic tests.
 =head2 Possible future directions
 
 I would also like to investigate the potential for an alternative to
-Template6::Parser that generates Raku closures without the use of EVAL.
+L<Template6::Parser|lib/Template6/Parser.rakumod> that generates Raku closures without the use of EVAL.
 This would be far trickier, and would not be compatible with the
 precompiled templates, but would be an interesting exercise nonetheless.
 


### PR DESCRIPTION
... so that it's easier to navigate to the relevant file when viewing the README online.

After @lizmat's comment in #28, I decided to rework it so that the changes are made in pod and thus make their way to the README as part of a release.